### PR TITLE
fix(sort): support sorting with secondary index queries

### DIFF
--- a/lib/controllers/list.js
+++ b/lib/controllers/list.js
@@ -69,7 +69,8 @@ List.prototype.fetch = function(req, res, context) {
       criteria = context.criteria || {},
       defaultCount = 100,
       count = +context.count || +req.query.count || defaultCount,
-      offset = +context.offset || +req.query.offset || 0;
+      offset = +context.offset || +req.query.offset || 0,
+      sortQuery = '';
 
   delete req.query.count;
   delete req.query.offset;
@@ -86,8 +87,7 @@ List.prototype.fetch = function(req, res, context) {
 
   var sortParam = this.resource.sort.param;
   if (_.has(req.query, sortParam) || !!this.resource.sort.default) {
-    var sortQuery = req.query[sortParam] || this.resource.sort.default || '';
-    query = this._applyOrderBy(query, sortQuery);
+    sortQuery = req.query[sortParam] || this.resource.sort.default || '';
     delete req.query[sortParam];
   }
 
@@ -107,6 +107,11 @@ List.prototype.fetch = function(req, res, context) {
   }
 
   var countQuery = query;
+
+  // apply sort if it was specified in the query
+  if (sortQuery) {
+    query = this._applyOrderBy(query, sortQuery);
+  }
 
   // apply offset/limit
   query = query.slice(offset, offset + count);

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -137,6 +137,17 @@ describe('Resource(search)', function() {
         { username: 'arthur', email: 'aaaaarthur@gmail.com' },
         { username: 'arthur', email: 'arthur@gmail.com' }
       ]
+    },
+    {
+      name: 'using a secondary index in combination with sort',
+      config: {
+        model: function() { return test.models.UserWithIndex; }
+      },
+      extraQuery: 'username=arthur&sort=username',
+      expectedResults: [
+        { username: 'arthur', email: 'aaaaarthur@gmail.com' },
+        { username: 'arthur', email: 'arthur@gmail.com' }
+      ]
     }
   ].forEach(function(testCase) {
     it('should search ' + testCase.name, function(done) {


### PR DESCRIPTION
Proposal to fix issue #1.

The list controller has been changed to apply the orderBy (based on query sort parameter) AFTER the secondary index filter has been applied. 

This fixes a 500 error being returned due to RethinkDB rejecting the final query. 
