### PR TITLE
tests(basic): testing updating documents with a non-id primary key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,13 +36,14 @@ module.exports = {
     options = options || {};
     if (!options.model)
       throw new Error('please specify a valid model');
-
+      
     if (!options.endpoints || !options.endpoints.length) {
       options.endpoints = [];
       var plural = inflection.pluralize(options.model._schema._model._name);
       var singular = inflection.singularize(options.model._schema._model._name);
+      var pk = options.model._schema._model._pk;
       options.endpoints.push('/' + plural);
-      options.endpoints.push('/' + singular + '/:id');
+      options.endpoints.push('/' + singular + '/:' + pk);  
     }
 
     var endpoints = [];

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -191,7 +191,6 @@ describe('Resource(basic)', function() {
         url: test.baseUrl + '/people_pkey',
         json: userData
       }, function(error, response, body) {
-        console.log(body);
         expect(response.statusCode).to.eql(201);
         expect(error).is.null;
         expect(response.headers.location).is.not.empty;

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -186,7 +186,7 @@ describe('Resource(basic)', function() {
     });
 
     it('should automatically generate a path for a new PersonPkey', function(done) {
-      let userData = {firstname:'John', lastname:'Doe'};
+      var userData = {firstname:'John', lastname:'Doe'};
       request.post({
         url: test.baseUrl + '/people_pkey',
         json: userData
@@ -355,7 +355,7 @@ describe('Resource(basic)', function() {
     });
 
     it('should fail to update a record when trying to change the primary key', function(done) {
-      let userData = {firstname:'John', lastname:'Doe'};
+      var userData = {firstname:'John', lastname:'Doe'};
       request.post({
         url: test.baseUrl + '/people_pkey',
         json: userData
@@ -377,7 +377,7 @@ describe('Resource(basic)', function() {
     });
 
     it('should only update lastname when trying to change primary key and lastname', function(done) {
-      let userData = {firstname:'John', lastname:'Doe'};
+      var userData = {firstname:'John', lastname:'Doe'};
       request.post({
         url: test.baseUrl + '/people_pkey',
         json: userData
@@ -400,7 +400,7 @@ describe('Resource(basic)', function() {
     });
 
     it('should update lastname when updating only lastname', function(done) {
-      let userData = {firstname:'John', lastname:'Doe'};
+      var userData = {firstname:'John', lastname:'Doe'};
       request.post({
         url: test.baseUrl + '/people_pkey',
         json: userData
@@ -434,7 +434,7 @@ describe('Resource(basic)', function() {
         expect(record).to.contain.keys('message');
         done();
       });
-    });
+    }); 
 
     it('should delete a record', function(done) {
       var userData = { username: 'chicken', email: 'chicken@gmail.com' };

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -62,8 +62,7 @@ describe('Resource(basic)', function() {
         });
 
         test.personPkeyResource = rest.resource({
-          model: test.models.PersonPkey,
-          endpoints: ['/people_pkey', '/person_pkey/:firstname']
+          model: test.models.PersonPkey
         });
 
         test.userResource.list.fetch.before(function(req, res, context) {
@@ -188,7 +187,7 @@ describe('Resource(basic)', function() {
     it('should automatically generate a path for a new PersonPkey', function(done) {
       var userData = {firstname:'John', lastname:'Doe'};
       request.post({
-        url: test.baseUrl + '/people_pkey',
+        url: test.baseUrl + '/person_pkeys',
         json: userData
       }, function(error, response, body) {
         expect(response.statusCode).to.eql(201);
@@ -230,7 +229,6 @@ describe('Resource(basic)', function() {
       }, function(error, response, body) {
         expect(error).is.null;
         expect(response.headers.location).is.not.empty;
-
         var path = response.headers.location;
         request.get({
           url: test.baseUrl + path
@@ -357,7 +355,7 @@ describe('Resource(basic)', function() {
     it('should fail to update a record when trying to change the primary key', function(done) {
       var userData = {firstname:'John', lastname:'Doe'};
       request.post({
-        url: test.baseUrl + '/people_pkey',
+        url: test.baseUrl + '/person_pkeys',
         json: userData
       }, function(error, response, body) {
         expect(response.statusCode).to.eql(201);
@@ -379,7 +377,7 @@ describe('Resource(basic)', function() {
     it('should only update lastname when trying to change primary key and lastname', function(done) {
       var userData = {firstname:'John', lastname:'Doe'};
       request.post({
-        url: test.baseUrl + '/people_pkey',
+        url: test.baseUrl + '/person_pkeys',
         json: userData
       }, function(error, response, body) {
         expect(response.statusCode).to.eql(201);
@@ -402,7 +400,7 @@ describe('Resource(basic)', function() {
     it('should update lastname when updating only lastname', function(done) {
       var userData = {firstname:'John', lastname:'Doe'};
       request.post({
-        url: test.baseUrl + '/people_pkey',
+        url: test.baseUrl + '/person_pkeys',
         json: userData
       }, function(error, response, body) {
         expect(response.statusCode).to.eql(201);


### PR DESCRIPTION
using the pkey field name in the singular endpoint url when creating
the rest resource prevents the pkey field from being overwritten
in REST PUTs. 
